### PR TITLE
Mockup generator positions

### DIFF
--- a/src/PrintfulMockupGenerator.php
+++ b/src/PrintfulMockupGenerator.php
@@ -7,8 +7,6 @@ namespace Printful;
 use Printful\Structures\Generator\GenerationResultItem;
 use Printful\Structures\Generator\MockupGenerationFile;
 use Printful\Structures\Generator\MockupGenerationParameters;
-use Printful\Structures\Generator\MockupItem;
-use Printful\Structures\Generator\MockupList;
 use Printful\Structures\Generator\PrintfileItem;
 use Printful\Structures\Generator\ProductPrintfiles;
 use Printful\Structures\Generator\Templates\PlacementConflictItem;
@@ -152,45 +150,22 @@ class PrintfulMockupGenerator
     }
 
     /**
-     * Generate mockup images for given Printful product and variants.
-     * This request can take up to multiple seconds!
-     *
-     * @param MockupGenerationParameters $parameters
-     * @return MockupList
-     * @throws Exceptions\PrintfulException
-     * @deprecated This function is deprecated and will be removed on 2017-11-01. Use createGenerationTask/getGenerationTask or createGenerationTaskAndWaitForResult.
-     *
-     * @see https://www.printful.com/docs/generator
-     * @see \Printful\PrintfulMockupGenerator::createGenerationTask
-     * @see \Printful\PrintfulMockupGenerator::getGenerationTask
-     * @see \Printful\PrintfulMockupGenerator::createGenerationTaskAndWaitForResult
-     */
-    public function generateMockups(MockupGenerationParameters $parameters)
-    {
-        $data = $this->parametersToArray($parameters);
-
-        $response = $this->printfulClient->post('/mockup-generator/generate/' . $parameters->productId, $data);
-
-        $mockupList = new MockupList;
-
-        $mockupList->mockups = array_map(function (array $rawMockup) {
-            return MockupItem::fromArray($rawMockup);
-        }, $response['mockups']);
-
-        return $mockupList;
-    }
-
-    /**
      * @param MockupGenerationParameters $parameters
      * @return array
      */
     private function parametersToArray(MockupGenerationParameters $parameters)
     {
         $files = array_map(function (MockupGenerationFile $file) {
-            return [
+            $re = [
                 'placement' => $file->placement,
                 'image_url' => $file->imageUrl,
             ];
+
+            if ($file->position) {
+                $re['position'] = $file->position->toArray();
+            }
+
+            return $re;
         }, $parameters->getFiles());
 
         $data = [

--- a/src/Structures/Generator/MockupGenerationFile.php
+++ b/src/Structures/Generator/MockupGenerationFile.php
@@ -18,4 +18,10 @@ class MockupGenerationFile
      * @var string
      */
     public $imageUrl;
+
+    /**
+     * Optional positions for generation
+     * @var MockupPositionItem
+     */
+    public $position;
 }

--- a/src/Structures/Generator/MockupGenerationParameters.php
+++ b/src/Structures/Generator/MockupGenerationParameters.php
@@ -57,14 +57,16 @@ class MockupGenerationParameters
      *
      * @param string $placement
      * @param $imageUrl
+     * @param MockupPositionItem|null $position Optional position for image for generation. If position is not provided, image will be fitted or stretched over the area.
      * @return self
      */
-    public function addImageUrl($placement, $imageUrl)
+    public function addImageUrl($placement, $imageUrl, MockupPositionItem $position = null)
     {
         $file = new MockupGenerationFile;
 
         $file->placement = $placement;
         $file->imageUrl = $imageUrl;
+        $file->position = $position;
 
         $this->files[] = $file;
 

--- a/src/Structures/Generator/MockupPositionItem.php
+++ b/src/Structures/Generator/MockupPositionItem.php
@@ -54,12 +54,12 @@ class MockupPositionItem
         }
 
         return [
-            'area_width' => (int)$this->areaWidth,
-            'area_height' => (int)$this->areaHeight,
-            'width' => (int)$this->width,
-            'height' => (int)$this->height,
-            'top' => (int)$this->top,
-            'left' => (int)$this->left,
+            'area_width' => (float)$this->areaWidth,
+            'area_height' => (float)$this->areaHeight,
+            'width' => (float)$this->width,
+            'height' => (float)$this->height,
+            'top' => (float)$this->top,
+            'left' => (float)$this->left,
         ];
     }
 }

--- a/src/Structures/Generator/MockupPositionItem.php
+++ b/src/Structures/Generator/MockupPositionItem.php
@@ -1,0 +1,65 @@
+<?php
+
+
+namespace Printful\Structures\Generator;
+
+use Printful\Exceptions\PrintfulException;
+
+class MockupPositionItem
+{
+    /**
+     * Positioning area width in pixels
+     * @var int
+     */
+    public $areaWidth;
+
+    /**
+     * Positioning area height in pixels
+     * @var int
+     */
+    public $areaHeight;
+
+    /**
+     * Image width within the area in pixels
+     * @var int
+     */
+    public $width;
+
+    /**
+     * Image height within the area in pixels
+     * @var int
+     */
+    public $height;
+
+    /**
+     * Image top offset from positioning area
+     * @var int
+     */
+    public $top;
+
+    /**
+     * Image left offset from positioning area
+     * @var int
+     */
+    public $left;
+
+    /**
+     * @return array
+     * @throws PrintfulException
+     */
+    public function toArray()
+    {
+        if ($this->width <= 0 || $this->height <= 0) {
+            throw new PrintfulException('Invalid size given for position item (less or equals zero)');
+        }
+
+        return [
+            'area_width' => (int)$this->areaWidth,
+            'area_height' => (int)$this->areaHeight,
+            'width' => (int)$this->width,
+            'height' => (int)$this->height,
+            'top' => (int)$this->top,
+            'left' => (int)$this->left,
+        ];
+    }
+}

--- a/tests/MockupGenerator/MockupGenerationTest.php
+++ b/tests/MockupGenerator/MockupGenerationTest.php
@@ -177,7 +177,17 @@ class MockupGenerationTest extends TestCase
         $parameters->productId = 19; // White Glossy Mug
         $parameters->variantIds = [1320];  // 11oz
 
-        $parameters->addImageUrl(Placements::TYPE_DEFAULT, $this->getDummyImageUrl(600, 400));
+        $position = new MockupPositionItem;
+        $position->areaWidth = 520;
+        $position->areaHeight = 202;
+        $position->width = 140;
+        $position->height = 63;
+        $position->top = 77;
+        $position->left = 43;
+
+        $imageUrl = $this->getDummyImageUrl(280, 126);
+
+        $parameters->addImageUrl(Placements::TYPE_DEFAULT, $imageUrl, $position);
 
         $result = $this->generator->createGenerationTaskAndWaitForResult($parameters)->mockupList;
 

--- a/tests/MockupGenerator/MockupGenerationTest.php
+++ b/tests/MockupGenerator/MockupGenerationTest.php
@@ -96,8 +96,19 @@ class MockupGenerationTest extends TestCase
             4018, // Black L
         ];
 
-        $parameters->addImageUrl(Placements::TYPE_FRONT, $this->getDummyImageUrl(600, 400));
-        $parameters->addImageUrl(Placements::TYPE_BACK, $this->getDummyImageUrl(600, 400));
+        // Positions for square image centered vertically, fits print file width
+        $position = new MockupPositionItem;
+        $position->areaWidth = 1800;
+        $position->areaHeight = 2400;
+        $position->width = 1800;
+        $position->height = 1800;
+        $position->top = 300;
+        $position->left = 0;
+
+        $dummyImage = $this->getDummyImageUrl(500, 500);
+
+        $parameters->addImageUrl(Placements::TYPE_FRONT, $dummyImage, $position);
+        $parameters->addImageUrl(Placements::TYPE_BACK, $dummyImage, $position);
 
         $result = $this->generator->createGenerationTaskAndWaitForResult($parameters)->mockupList;
 

--- a/tests/MockupGenerator/MockupGenerationTest.php
+++ b/tests/MockupGenerator/MockupGenerationTest.php
@@ -180,12 +180,12 @@ class MockupGenerationTest extends TestCase
         $position = new MockupPositionItem;
         $position->areaWidth = 520;
         $position->areaHeight = 202;
-        $position->width = 140;
-        $position->height = 63;
-        $position->top = 77;
-        $position->left = 43;
+        $position->width = 70;
+        $position->height = 70;
+        $position->left = 225;
+        $position->top = 66;
 
-        $imageUrl = $this->getDummyImageUrl(280, 126);
+        $imageUrl = $this->getDummyImageUrl(700, 700);
 
         $parameters->addImageUrl(Placements::TYPE_DEFAULT, $imageUrl, $position);
 

--- a/tests/MockupGenerator/MockupGenerationTest.php
+++ b/tests/MockupGenerator/MockupGenerationTest.php
@@ -6,6 +6,7 @@ namespace Printful\Tests\MockupGenerator;
 
 use Printful\PrintfulMockupGenerator;
 use Printful\Structures\Generator\MockupGenerationParameters;
+use Printful\Structures\Generator\MockupPositionItem;
 use Printful\Structures\Placements;
 use Printful\Tests\TestCase;
 
@@ -29,7 +30,16 @@ class MockupGenerationTest extends TestCase
             2, // 24x36
         ];
 
-        $parameters->addImageUrl(Placements::TYPE_DEFAULT, 'https://dummyimage.com/600x400/000/fff');
+        // Relative positions that will result in image that is in center of the poster in half the width
+        $position = new MockupPositionItem;
+        $position->areaWidth = 1000;
+        $position->areaHeight = 1000;
+        $position->width = 500;
+        $position->height = 500;
+        $position->top = 250;
+        $position->left = 250;
+
+        $parameters->addImageUrl(Placements::TYPE_DEFAULT, $this->getDummyImageUrl(500, 500), $position);
 
         $result = $this->generator->createGenerationTaskAndWaitForResult($parameters)->mockupList;
 
@@ -66,8 +76,8 @@ class MockupGenerationTest extends TestCase
             4018, // Black L
         ];
 
-        $parameters->addImageUrl(Placements::TYPE_FRONT, 'https://dummyimage.com/600x400/000/fff');
-        $parameters->addImageUrl(Placements::TYPE_BACK, 'https://dummyimage.com/600x400/000/fff');
+        $parameters->addImageUrl(Placements::TYPE_FRONT, $this->getDummyImageUrl(600, 400));
+        $parameters->addImageUrl(Placements::TYPE_BACK, $this->getDummyImageUrl(600, 400));
 
         $result = $this->generator->createGenerationTaskAndWaitForResult($parameters)->mockupList;
 
@@ -92,10 +102,10 @@ class MockupGenerationTest extends TestCase
             7853, // White
         ];
 
-        $parameters->addImageUrl(Placements::TYPE_EMBROIDERY_FRONT, 'https://dummyimage.com/600x400/000/fff');
-        $parameters->addImageUrl(Placements::TYPE_EMBROIDERY_LEFT, 'https://dummyimage.com/600x400/000/fff');
-        $parameters->addImageUrl(Placements::TYPE_EMBROIDERY_RIGHT, 'https://dummyimage.com/600x400/000/fff');
-        $parameters->addImageUrl(Placements::TYPE_EMBROIDERY_BACK, 'https://dummyimage.com/600x400/000/fff');
+        $parameters->addImageUrl(Placements::TYPE_EMBROIDERY_FRONT, $this->getDummyImageUrl(600, 400));
+        $parameters->addImageUrl(Placements::TYPE_EMBROIDERY_LEFT, $this->getDummyImageUrl(600, 400));
+        $parameters->addImageUrl(Placements::TYPE_EMBROIDERY_RIGHT, $this->getDummyImageUrl(600, 400));
+        $parameters->addImageUrl(Placements::TYPE_EMBROIDERY_BACK, $this->getDummyImageUrl(600, 400));
 
         $result = $this->generator->createGenerationTaskAndWaitForResult($parameters)->mockupList;
 
@@ -123,7 +133,7 @@ class MockupGenerationTest extends TestCase
         $parameters->options = ['Back'];
         $parameters->optionGroups = ['High-heels'];
 
-        $parameters->addImageUrl(Placements::TYPE_DEFAULT, 'https://dummyimage.com/600x400/000/fff');
+        $parameters->addImageUrl(Placements::TYPE_DEFAULT, $this->getDummyImageUrl(600, 400));
 
         $result = $this->generator->createGenerationTaskAndWaitForResult($parameters)->mockupList;
 
@@ -136,7 +146,7 @@ class MockupGenerationTest extends TestCase
         $parameters->productId = 19; // White Glossy Mug
         $parameters->variantIds = [1320];  // 11oz
 
-        $parameters->addImageUrl(Placements::TYPE_DEFAULT, 'https://dummyimage.com/600x400/000/fff');
+        $parameters->addImageUrl(Placements::TYPE_DEFAULT, $this->getDummyImageUrl(600, 400));
 
         $result = $this->generator->createGenerationTaskAndWaitForResult($parameters)->mockupList;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,4 +33,15 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     {
         return new PrintfulMockupGenerator($this->api);
     }
+
+    /**
+     * @param int $width
+     * @param int $height
+     * @return string
+     */
+    protected function getDummyImageUrl($width, $height)
+    {
+        return 'http://lorempixel.com/' . $width . '/' . $height;
+        // return 'https://dummyimage.com/' . $width . 'x' . $height . '/000/fff';
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -41,7 +41,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
      */
     protected function getDummyImageUrl($width, $height)
     {
-        return 'http://lorempixel.com/' . $width . '/' . $height;
-        // return 'https://dummyimage.com/' . $width . 'x' . $height . '/000/fff';
+        // return 'http://lorempixel.com/' . $width . '/' . $height;
+        return 'https://dummyimage.com/' . $width . 'x' . $height . '/000/fff';
     }
 }


### PR DESCRIPTION
Remove deprected mockup generation method (use `createGenerationTask`)
Now mockup generation supports custom positions for images (no need to generate a printfile, just pass positions for the original file)